### PR TITLE
Ensure package-lock.json is updated if package.json changes

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -1,4 +1,9 @@
-import {message, danger} from "danger"
+import {warn, danger} from "danger"
 
-const newFiles = danger.git.created_files.join("- ")
-message("New Files in this PR: \n - " + newFiles);
+// Always update package-lock when you install a new module
+const packageChanged = danger.git.modified_files.includes('package.json');
+const lockfileChanged = danger.git.modified_files.includes('package-lock.json');
+
+if (packageChanged && !lockfileChanged) {
+  warn('Changes were made to package.json, but not to package-lock.json - <i>Perhaps you need to run `npm install`</i>');
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "url": "https://github.com/jonathan-fielding/danger-js-example/issues"
   },
   "homepage": "https://github.com/jonathan-fielding/danger-js-example#readme",
-  "dependencies": {},
+  "dependencies": {
+    "node-fetch": "^2.6.1"
+  },
   "devDependencies": {
     "danger": "^10.4.0"
   }


### PR DESCRIPTION
When a new node package is installed from npm it results in a change to both the package.json and package-lock.json files. Both of these should be commited to the repository so this check will ensure you don't forget to commit the lock file if the package.json has changed.